### PR TITLE
feat: splash screen implemented

### DIFF
--- a/lib/features/exports.dart
+++ b/lib/features/exports.dart
@@ -1,1 +1,3 @@
 export 'package:githun_api_commits/features/splash/presentation/screens/splash_screen.dart';
+
+export 'package:githun_api_commits/features/github/dashboard/presentation/screens/dashboard_screen.dart';

--- a/lib/features/github/dashboard/presentation/screens/dashboard_screen.dart
+++ b/lib/features/github/dashboard/presentation/screens/dashboard_screen.dart
@@ -1,0 +1,26 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:githun_api_commits/app/core/design/design.dart';
+
+@RoutePage()
+class DashboardScreen extends StatefulWidget {
+  static const String routeName = '/dashboardScreen';
+
+  const DashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -1,8 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:githun_api_commits/app/gen/assets.gen.dart';
+import 'package:githun_api_commits/routes/app_route.dart';
 
 @RoutePage()
 class SplashScreen extends StatefulWidget {
+  static const String routeName = '/splashScreen';
+
   const SplashScreen({super.key});
 
   @override
@@ -11,10 +15,30 @@ class SplashScreen extends StatefulWidget {
 
 class _SplashScreenState extends State<SplashScreen> {
   @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(milliseconds: 1500), () async {
+      await context.router.pushAndPopUntil(
+        const DashboardRoute(),
+        predicate: (_) => false,
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
-        child: Text('Splash Screen'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Image.asset(
+              AssetsToken.icons.githubIcon.path,
+            ),
+            const SizedBox(height: 40),
+            const CircularProgressIndicator()
+          ],
+        ),
       ),
     );
   }

--- a/lib/routes/app_route.dart
+++ b/lib/routes/app_route.dart
@@ -8,5 +8,6 @@ class AppRouter extends _$AppRouter {
   @override
   List<AutoRoute> get routes => [
         AutoRoute(page: SplashRoute.page, initial: true),
+        AutoRoute(page: DashboardRoute.page),
       ];
 }

--- a/lib/routes/app_route.gr.dart
+++ b/lib/routes/app_route.gr.dart
@@ -15,13 +15,33 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
+    DashboardRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const DashboardScreen(),
+      );
+    },
     SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const SplashScreen(),
       );
-    }
+    },
   };
+}
+
+/// generated route for
+/// [DashboardScreen]
+class DashboardRoute extends PageRouteInfo<void> {
+  const DashboardRoute({List<PageRouteInfo>? children})
+      : super(
+          DashboardRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'DashboardRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for


### PR DESCRIPTION
This pull request adds the implementation of the splash screen and dashboard screen to the project. The splash screen displays a logo and a loading indicator before navigating to the dashboard screen after a delay. The dashboard screen is a placeholder screen with a centered column.